### PR TITLE
Require an index.js module by the name of its parent directory

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 node_modules/
 output.js
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ var Role = require('Role')
 
 It will translate `'NuclearEventEmitter'` to `src/io/NuclearEventEmitter.js` for you. And the same happens to `UserStore` and `Role`.
 
+### What about requiring `index.js` by parent folder name?
+It is common to require an `index.js` file by the name of its parent directory, for example:
+
+    src
+      security
+        authorisation
+          index.js
+
+Old require statement:
+
+```JS
+require('./security/authorisation')
+```
+
+New require statement with the plugin:
+
+```JS
+require('authorisation')
+```
+
+This behaviour follows the same conflict resolution procedure outlined below.
+
 ### But what about conflicts?
 Given the following structure:
 ```

--- a/src/__tests__/resolveConflict-test.js
+++ b/src/__tests__/resolveConflict-test.js
@@ -1,8 +1,9 @@
 var chai = require('chai')
 var resolveConflict = require('../resolveConflict')
-var sep = require('path').sep
+var path = require('path')
 
 var expect = chai.expect
+var sep = path.sep
 
 function p(path) {
     return path.replace(/\//g, sep);
@@ -13,27 +14,34 @@ describe('resolveConflict', function() {
     expect(
       resolveConflict([
         {
-          path: p('src/deep/sum.js'),
-          name: 'sum'
+          name: 'sum',
+          path: p('src/deep/sum.js')
         }, {
-          path: p('src/deep/deep/sum.js'),
-          name: 'sum'
+          name: 'sum',
+          path: p('src/deep/deep/sum.js')
         }, {
-          path: p('src/deep/deep/divide.js'),
-          name: 'divide'
+          name: 'divide',
+          path: p('src/deep/deep/divide.js')
+        }, {
+          name: 'index',
+          path: p('src/deep/deep/divide/index.js')
         }
       ])
     ).to.eql([
       {
-        path: p('src/deep/deep/divide.js'),
-        name: 'divide'
+        name: 'deep/sum',
+        path: p('src/deep/sum.js')
+      }, {
+        name: 'deep/deep/sum',
+        path: p('src/deep/deep/sum.js')
       },
       {
-        path: p('src/deep/sum.js'),
-        name: 'deep/sum'
-      }, {
-        path: p('src/deep/deep/sum.js'),
-        name: 'deep/deep/sum'
+        name: 'deep/divide',
+        path: p('src/deep/deep/divide.js')
+      },
+      {
+        name: 'deep/deep/divide',
+        path: p('src/deep/deep/divide/index.js')
       }
     ])
   })
@@ -50,6 +58,9 @@ describe('resolveConflict', function() {
         }, {
           name: 'conflict',
           path: p('src/foo/bar/deep/deep/conflict.js')
+        }, {
+          name: 'index',
+          path: p('src/foo/bar/baz/deep/deep/conflict/index.js')
         }
       ])
     ).to.eql([
@@ -62,6 +73,9 @@ describe('resolveConflict', function() {
       }, {
         name: 'deep/deep/conflict',
         path: p('src/foo/bar/deep/deep/conflict.js')
+      }, {
+        name: 'baz/deep/deep/conflict',
+        path: p('src/foo/bar/baz/deep/deep/conflict/index.js')
       }
     ])
   })
@@ -78,6 +92,9 @@ describe('resolveConflict', function() {
         }, {
           name: 'sum',
           path: p('src/foo/cool/math/sum.js')
+        }, {
+          name: 'index',
+          path: p('src/foo/cool/math/sum/index.js')
         }, {
           name: 'div',
           path: p('src/math/div.js')
@@ -100,6 +117,9 @@ describe('resolveConflict', function() {
         name: 'cool/math/sum',
         path: p('src/foo/cool/math/sum.js')
       }, {
+        name: 'foo/cool/math/sum',
+        path: p('src/foo/cool/math/sum/index.js')
+      }, {
         name: 'math/div',
         path: p('src/math/div.js')
       }, {
@@ -118,15 +138,55 @@ describe('resolveConflict', function() {
         [
           {
             name: 'sum',
-            path: p('src/math/sum.js')
+            path: p('src/sum.js')
+          }, {
+            name: 'index',
+            path: p('src/sum/index.js')
+          }, {
+            name: 'index',
+            path: p('src/bar/divide/index.js')
           }
         ],
-        ['sum']
+        ['sum', 'divide']
       )
     ).to.eql([
       {
-        name: 'math/sum',
-        path: p('src/math/sum.js')
+        name: 'bar/divide',
+        path: p('src/bar/divide/index.js')
+      }, {
+        name: 'src/sum',
+        path: p('src/sum.js')
+      }, {
+        name: 'sum',
+        path: p('src/sum/index.js')
+      }
+    ])
+  })
+
+  it('resolves conflicts with multiple index.js', function() {
+    expect(
+      resolveConflict([
+        {
+          name: 'index',
+          path: p('src/deep/sum/index.js')
+        }, {
+          name: 'index',
+          path: p('src/deep/deep/sum/index.js')
+        }, {
+          name: 'index',
+          path: p('src/deep/deep/divide/index.js')
+        }
+      ])
+    ).to.eql([
+      {
+        name: 'divide',
+        path: p('src/deep/deep/divide/index.js')
+      }, {
+        name: 'deep/sum',
+        path: p('src/deep/sum/index.js')
+      }, {
+        name: 'deep/deep/sum',
+        path: p('src/deep/deep/sum/index.js')
       }
     ])
   })

--- a/src/__tests__/resolveConflict-test.js
+++ b/src/__tests__/resolveConflict-test.js
@@ -1,33 +1,38 @@
 var chai = require('chai')
 var resolveConflict = require('../resolveConflict')
+var sep = require('path').sep
 
 var expect = chai.expect
+
+function p(path) {
+    return path.replace(/\//g, sep);
+}
 
 describe('resolveConflict', function() {
   it('resolves conflict respecting dirname', function() {
     expect(
       resolveConflict([
         {
-          path: 'src/deep/sum.js',
+          path: p('src/deep/sum.js'),
           name: 'sum'
         }, {
-          path: 'src/deep/deep/sum.js',
+          path: p('src/deep/deep/sum.js'),
           name: 'sum'
         }, {
-          path: 'src/deep/deep/divide.js',
+          path: p('src/deep/deep/divide.js'),
           name: 'divide'
         }
       ])
     ).to.eql([
       {
-        path: 'src/deep/deep/divide.js',
+        path: p('src/deep/deep/divide.js'),
         name: 'divide'
       },
       {
-        path: 'src/deep/sum.js',
+        path: p('src/deep/sum.js'),
         name: 'deep/sum'
       }, {
-        path: 'src/deep/deep/sum.js',
+        path: p('src/deep/deep/sum.js'),
         name: 'deep/deep/sum'
       }
     ])
@@ -38,25 +43,25 @@ describe('resolveConflict', function() {
       resolveConflict([
         {
           name: 'conflict',
-          path: 'src/foo/deep/conflict.js'
+          path: p('src/foo/deep/conflict.js')
         }, {
           name: 'conflict',
-          path: 'src/foo/deep/bar/conflict.js'
+          path: p('src/foo/deep/bar/conflict.js')
         }, {
           name: 'conflict',
-          path: 'src/foo/bar/deep/deep/conflict.js'
+          path: p('src/foo/bar/deep/deep/conflict.js')
         }
       ])
     ).to.eql([
       {
         name: 'deep/conflict',
-        path: 'src/foo/deep/conflict.js'
+        path: p('src/foo/deep/conflict.js')
       }, {
         name: 'bar/conflict',
-        path: 'src/foo/deep/bar/conflict.js'
+        path: p('src/foo/deep/bar/conflict.js')
       }, {
         name: 'deep/deep/conflict',
-        path: 'src/foo/bar/deep/deep/conflict.js'
+        path: p('src/foo/bar/deep/deep/conflict.js')
       }
     ])
   })
@@ -66,43 +71,43 @@ describe('resolveConflict', function() {
       resolveConflict([
         {
           name: 'sum',
-          path: 'src/math/sum.js'
+          path: p('src/math/sum.js')
         }, {
           name: 'sum',
-          path: 'src/deep/math/sum.js'
+          path: p('src/deep/math/sum.js')
         }, {
           name: 'sum',
-          path: 'src/foo/cool/math/sum.js'
+          path: p('src/foo/cool/math/sum.js')
         }, {
           name: 'div',
-          path: 'src/math/div.js'
+          path: p('src/math/div.js')
         }, {
           name: 'div',
-          path: 'src/deep/math/div.js',
+          path: p('src/deep/math/div.js')
         }, {
           name: 'div',
-          path: 'src/foo/cool/math/div.js'
+          path: p('src/foo/cool/math/div.js')
         }
       ])
     ).to.eql([
       {
         name: 'math/sum',
-        path: 'src/math/sum.js'
+        path: p('src/math/sum.js')
       }, {
         name: 'deep/math/sum',
-        path: 'src/deep/math/sum.js'
+        path: p('src/deep/math/sum.js')
       }, {
         name: 'cool/math/sum',
-        path: 'src/foo/cool/math/sum.js'
+        path: p('src/foo/cool/math/sum.js')
       }, {
         name: 'math/div',
-        path: 'src/math/div.js'
+        path: p('src/math/div.js')
       }, {
         name: 'deep/math/div',
-        path: 'src/deep/math/div.js',
+        path: p('src/deep/math/div.js')
       }, {
         name: 'cool/math/div',
-        path: 'src/foo/cool/math/div.js'
+        path: p('src/foo/cool/math/div.js')
       }
     ])
   })
@@ -113,7 +118,7 @@ describe('resolveConflict', function() {
         [
           {
             name: 'sum',
-            path: 'src/math/sum.js'
+            path: p('src/math/sum.js')
           }
         ],
         ['sum']
@@ -121,7 +126,7 @@ describe('resolveConflict', function() {
     ).to.eql([
       {
         name: 'math/sum',
-        path: 'src/math/sum.js'
+        path: p('src/math/sum.js')
       }
     ])
   })

--- a/src/resolveConflict.js
+++ b/src/resolveConflict.js
@@ -24,13 +24,10 @@ module.exports = function resolveConflict(
 
     while (parts.length) {
       var pop = parts.pop()
-      var proposal = pop.concat(path.sep, current.name)
+      var proposal = pop.concat('/', current.name)
 
       if (previous.length) {
-        proposal = path.join.apply(
-          null,
-          [pop].concat(previous, current.name)
-        )
+        proposal = [pop].concat(previous, current.name).join('/')
       }
 
       if (! solutions[proposal]) {


### PR DESCRIPTION
The plugin currently does not support globally requiring an `index.js` file by the name of its parent directory. Updates to the `README.md` and issue #7 should explain the desire for this functionality, which has been added with this pull request. There are no changes to existing behaviour or public API.

As well as implementing the aforementioned functionality, I have updated the tests to be Windows friendly. (Note: I don't have a non-Windows machine to test my changes on.)

Let me know if you have any questions; I did some refactoring but I hope it is still clear what it is going on.

P.S. Great plugin, btw. Thank you. :-)
